### PR TITLE
Feature/multiple input files

### DIFF
--- a/cmd/bedfusion/main.go
+++ b/cmd/bedfusion/main.go
@@ -46,6 +46,13 @@ func main() {
 		fmt.Fprintf(os.Stderr, "error while sorting: %q\n", err)
 		s.ctx.Exit(1)
 	}
+	// Deduplicate if chosen and we have not merged
+	// Must be used after sort as it requires the lines to be sorted
+	// before use
+	if s.Bedfile.Deduplicate && s.Bedfile.NoMerge {
+		s.Bedfile.DeduplicateLines()
+	}
+
 	// Write output
 	if err := s.Bedfile.Write(); err != nil {
 		fmt.Fprintf(os.Stderr, "error while writing: %q\n", err)

--- a/internal/bed/bed.go
+++ b/internal/bed/bed.go
@@ -20,9 +20,9 @@ type Bedfile struct {
 
 	SortType    string   `env:"SORT_TYPE" group:"sorting" enum:"lex,nat,ccs" default:"lex" short:"s" help:"How the bed file should be sorted. lex = lexicographic sorting (chr: 1 < 10 < 2 < MT < X), nat = natural sorting (chr: 1 < 2 < 10 < MT < X), ccs = custom chromosome sorting (see --chr-order flag )"`
 	ChrOrder    []string `env:"CHR_ORDER" group:"sorting" help:"Comma separated custom chromosome order, to be used with custom chromosome sorting (--sort-type=ccs). Chromosomes not on the list will be sorted naturally after the ones in the list. If none is provided human chromosome order will be used (1-21, X, Y, MT)"`
-	Deduplicate bool     `env:"DEDUPLICATE" group:"sorting" cmd:"" default:"false" short:"d" help:"Remove duplicated lines when used together with --no-merge"`
+	Deduplicate bool     `env:"DEDUPLICATE" group:"sorting" cmd:"" short:"d" help:"Remove duplicated lines"`
 
-	NoMerge bool `env:"NO_MERGE" group:"merging,sorting" cmd:"" default:"false" help:"Do not merge bed file. Note that touching regions are merged (e.g. if two regions are on the same chr they will be merged if one ends at 5 and the other starts at 6)"`
+	NoMerge bool `env:"NO_MERGE" group:"merging" cmd:"" help:"Do not merge bed file. Note that touching regions are merged (e.g. if two regions are on the same chr they will be merged if one ends at 5 and the other starts at 6)"`
 	Overlap int  `env:"OVERLAP" group:"merging" default:"0" help:"Overlap between regions to be merged. This can be a positive or negative number (e.g. if you don't want touching regions to be merged set overlap to -1)"`
 
 	Header      []string `kong:"-"`

--- a/internal/bed/bed.go
+++ b/internal/bed/bed.go
@@ -12,7 +12,7 @@ var humanChrOrder = []string{"1", "chr1", "2", "chr2", "3", "chr3", "4", "chr4",
 // Note that the the user will give the columns with 1-based indexing,
 // but that we convert this to zero-based indexing in .VerifyAndHandle()
 type Bedfile struct {
-	Inputs []string `arg:"" help:"Bed file path(s)"`
+	Inputs []string `arg:"" help:"Bed file path(s). If more than one is provided the files will be joined as if they were one file"`
 	Output string   `env:"OUTPUT_FILE" short:"o" help:"Path to the output file. If unset the output will be written to stdout"`
 
 	StrandCol int `env:"STRAND_COL" group:"input" help:"The column containing the strand information (1-based column index). If this option is set regions on the same strand will not be merged"`
@@ -22,7 +22,7 @@ type Bedfile struct {
 	ChrOrder    []string `env:"CHR_ORDER" group:"sorting" help:"Comma separated custom chromosome order, to be used with custom chromosome sorting (--sort-type=ccs). Chromosomes not on the list will be sorted naturally after the ones in the list. If none is provided human chromosome order will be used (1-21, X, Y, MT)"`
 	Deduplicate bool     `env:"DEDUPLICATE" group:"sorting" cmd:"" short:"d" help:"Remove duplicated lines"`
 
-	NoMerge bool `env:"NO_MERGE" group:"merging" cmd:"" help:"Do not merge bed file. Note that touching regions are merged (e.g. if two regions are on the same chr they will be merged if one ends at 5 and the other starts at 6)"`
+	NoMerge bool `env:"NO_MERGE" group:"merging" cmd:"" help:"Do not merge bed regions. Note that touching regions are merged (e.g. if two regions are on the same chr they will be merged if one ends at 5 and the other starts at 6)"`
 	Overlap int  `env:"OVERLAP" group:"merging" default:"0" help:"Overlap between regions to be merged. This can be a positive or negative number (e.g. if you don't want touching regions to be merged set overlap to -1)"`
 
 	Header      []string `kong:"-"`

--- a/internal/bed/bed.go
+++ b/internal/bed/bed.go
@@ -12,8 +12,8 @@ var humanChrOrder = []string{"1", "chr1", "2", "chr2", "3", "chr3", "4", "chr4",
 // Note that the the user will give the columns with 1-based indexing,
 // but that we convert this to zero-based indexing in .VerifyAndHandle()
 type Bedfile struct {
-	Input  string `arg:"" help:"Bed file path"`
-	Output string `env:"OUTPUT_FILE" short:"o" help:"Path to the output file. If unset the output will be written to stdout"`
+	Inputs []string `arg:"" help:"Bed file path(s)"`
+	Output string   `env:"OUTPUT_FILE" short:"o" help:"Path to the output file. If unset the output will be written to stdout"`
 
 	StrandCol int `env:"STRAND_COL" group:"input" help:"The column containing the strand information (1-based column index). If this option is set regions on the same strand will not be merged"`
 	FeatCol   int `env:"FEAT_COL" group:"input" help:"The column containing the feature (e.g. gene id, transcript id etc.) information (1-based column index). If this option is set regions on the same feature will not be merged"`
@@ -45,7 +45,7 @@ const (
 	stopIdx  = 2
 )
 
-// Verifies the user input for Bedfile, adds a chrOrderMap, fixes paths
+// Verifies the user input for Bedfiles, adds a chrOrderMap, fixes paths
 // and subtracts 1 from cols to be able to use zero-based indexing
 func (bf *Bedfile) VerifyAndHandle() error {
 	if bf.StrandCol != 0 {
@@ -71,7 +71,10 @@ func (bf *Bedfile) VerifyAndHandle() error {
 		}
 		bf.chrOrderMap = chrOrderToMap(bf.ChrOrder)
 	}
-	bf.Input = filepath.Clean(bf.Input)
+	// Clean input paths
+	for i, input := range bf.Inputs {
+		bf.Inputs[i] = filepath.Clean(input)
+	}
 	if bf.Output != "" {
 		bf.Output = filepath.Clean(bf.Output)
 	}

--- a/internal/bed/bed.go
+++ b/internal/bed/bed.go
@@ -18,10 +18,11 @@ type Bedfile struct {
 	StrandCol int `env:"STRAND_COL" group:"input" help:"The column containing the strand information (1-based column index). If this option is set regions on the same strand will not be merged"`
 	FeatCol   int `env:"FEAT_COL" group:"input" help:"The column containing the feature (e.g. gene id, transcript id etc.) information (1-based column index). If this option is set regions on the same feature will not be merged"`
 
-	SortType string   `env:"SORT_TYPE" group:"sorting" enum:"lex,nat,ccs" default:"lex" short:"s" help:"How the bed file should be sorted. lex = lexicographic sorting (chr: 1 < 10 < 2 < MT < X), nat = natural sorting (chr: 1 < 2 < 10 < MT < X), ccs = custom chromosome sorting (see --chr-order flag )"`
-	ChrOrder []string `env:"CHR_ORDER" group:"sorting" help:"Comma separated custom chromosome order, to be used with custom chromosome sorting (--sort-type=ccs). Chromosomes not on the list will be sorted naturally after the ones in the list. If none is provided human chromosome order will be used (1-21, X, Y, MT)"`
+	SortType    string   `env:"SORT_TYPE" group:"sorting" enum:"lex,nat,ccs" default:"lex" short:"s" help:"How the bed file should be sorted. lex = lexicographic sorting (chr: 1 < 10 < 2 < MT < X), nat = natural sorting (chr: 1 < 2 < 10 < MT < X), ccs = custom chromosome sorting (see --chr-order flag )"`
+	ChrOrder    []string `env:"CHR_ORDER" group:"sorting" help:"Comma separated custom chromosome order, to be used with custom chromosome sorting (--sort-type=ccs). Chromosomes not on the list will be sorted naturally after the ones in the list. If none is provided human chromosome order will be used (1-21, X, Y, MT)"`
+	Deduplicate bool     `env:"DEDUPLICATE" group:"sorting" cmd:"" default:"false" short:"d" help:"Remove duplicated lines when used together with --no-merge"`
 
-	NoMerge bool `env:"NO_MERGE" group:"merging" cmd:"" default:"false" help:"Do not merge bed file. Note that touching regions are merged (e.g. if two regions are on the same chr they will be merged if one ends at 5 and the other starts at 6)"`
+	NoMerge bool `env:"NO_MERGE" group:"merging,sorting" cmd:"" default:"false" help:"Do not merge bed file. Note that touching regions are merged (e.g. if two regions are on the same chr they will be merged if one ends at 5 and the other starts at 6)"`
 	Overlap int  `env:"OVERLAP" group:"merging" default:"0" help:"Overlap between regions to be merged. This can be a positive or negative number (e.g. if you don't want touching regions to be merged set overlap to -1)"`
 
 	Header      []string `kong:"-"`

--- a/internal/bed/bed_test.go
+++ b/internal/bed/bed_test.go
@@ -25,21 +25,21 @@ func TestVerifyAndHandle(t *testing.T) {
 		{
 			testing: "correct input, only input path",
 			bed: Bedfile{
-				Input: "/some/path/test.bed",
+				Inputs: []string{"/some/path/test.bed"},
 			},
 			expectedBed: Bedfile{
-				Input: "/some/path/test.bed",
+				Inputs: []string{"/some/path/test.bed"},
 			},
 		},
 		{
 			testing: "correct input with strand col",
 			bed: Bedfile{
-				Input:     "/some/path/test.bed",
+				Inputs:    []string{"/some/path/test.bed"},
 				Output:    "/some/output/path/output.bed",
 				StrandCol: 4,
 			},
 			expectedBed: Bedfile{
-				Input:     "/some/path/test.bed",
+				Inputs:    []string{"/some/path/test.bed"},
 				Output:    "/some/output/path/output.bed",
 				StrandCol: 3,
 			},
@@ -47,12 +47,12 @@ func TestVerifyAndHandle(t *testing.T) {
 		{
 			testing: "correct input with feat col",
 			bed: Bedfile{
-				Input:   "/some/path/test.bed",
+				Inputs:  []string{"/some/path/test.bed"},
 				Output:  "/some/output/path/output.bed",
 				FeatCol: 3,
 			},
 			expectedBed: Bedfile{
-				Input:   "/some/path/test.bed",
+				Inputs:  []string{"/some/path/test.bed"},
 				Output:  "/some/output/path/output.bed",
 				FeatCol: 2,
 			},
@@ -60,13 +60,13 @@ func TestVerifyAndHandle(t *testing.T) {
 		{
 			testing: "correct input with both cols",
 			bed: Bedfile{
-				Input:     "/some/path/test.bed",
+				Inputs:    []string{"/some/path/test.bed"},
 				Output:    "/some/output/path/output.bed",
 				StrandCol: 4,
 				FeatCol:   3,
 			},
 			expectedBed: Bedfile{
-				Input:     "/some/path/test.bed",
+				Inputs:    []string{"/some/path/test.bed"},
 				Output:    "/some/output/path/output.bed",
 				StrandCol: 3,
 				FeatCol:   2,
@@ -75,13 +75,13 @@ func TestVerifyAndHandle(t *testing.T) {
 		{
 			testing: "unclean paths",
 			bed: Bedfile{
-				Input:     "/some/../path/test.bed",
+				Inputs:    []string{"/some/../path/test1.bed", "./some/../path/./test2.bed"},
 				Output:    "/some/./output/./path/./output.bed",
 				StrandCol: 4,
 				FeatCol:   3,
 			},
 			expectedBed: Bedfile{
-				Input:     "/path/test.bed",
+				Inputs:    []string{"/path/test1.bed", "path/test2.bed"},
 				Output:    "/some/output/path/output.bed",
 				StrandCol: 3,
 				FeatCol:   2,
@@ -90,11 +90,11 @@ func TestVerifyAndHandle(t *testing.T) {
 		{
 			testing: "sortType is ccs, and chrOrder is empty",
 			bed: Bedfile{
-				Input:    "/some/path/test.bed",
+				Inputs:   []string{"/some/path/test.bed"},
 				SortType: "ccs",
 			},
 			expectedBed: Bedfile{
-				Input:       "/some/path/test.bed",
+				Inputs:      []string{"/some/path/test.bed"},
 				SortType:    "ccs",
 				ChrOrder:    humanChrOrder,
 				chrOrderMap: chrOrderToMap(humanChrOrder),
@@ -103,12 +103,12 @@ func TestVerifyAndHandle(t *testing.T) {
 		{
 			testing: "sortType is ccs, and is set",
 			bed: Bedfile{
-				Input:    "/some/path/test.bed",
+				Inputs:   []string{"/some/path/test.bed"},
 				SortType: "ccs",
 				ChrOrder: []string{"4", "3", "2", "1"},
 			},
 			expectedBed: Bedfile{
-				Input:    "/some/path/test.bed",
+				Inputs:   []string{"/some/path/test.bed"},
 				SortType: "ccs",
 				ChrOrder: []string{"4", "3", "2", "1"},
 				chrOrderMap: map[string]int{
@@ -122,7 +122,7 @@ func TestVerifyAndHandle(t *testing.T) {
 		{
 			testing: "strand col less than 3",
 			bed: Bedfile{
-				Input:     "/some/path/test.bed",
+				Inputs:    []string{"/some/path/test.bed"},
 				Output:    "/some/output/path/output.bed",
 				StrandCol: 2,
 				FeatCol:   3,
@@ -132,7 +132,7 @@ func TestVerifyAndHandle(t *testing.T) {
 		{
 			testing: "feat col less than 3",
 			bed: Bedfile{
-				Input:     "/some/path/test.bed",
+				Inputs:    []string{"/some/path/test.bed"},
 				Output:    "/some/output/path/output.bed",
 				StrandCol: 4,
 				FeatCol:   2,
@@ -142,7 +142,7 @@ func TestVerifyAndHandle(t *testing.T) {
 		{
 			testing: "overlapping strand and feat cols",
 			bed: Bedfile{
-				Input:     "/some/path/test.bed",
+				Inputs:    []string{"/some/path/test.bed"},
 				Output:    "/some/output/path/output.bed",
 				StrandCol: 4,
 				FeatCol:   4,

--- a/internal/bed/deduplicate.go
+++ b/internal/bed/deduplicate.go
@@ -1,0 +1,18 @@
+package bed
+
+import (
+	"strings"
+)
+
+// Remove duplicates
+// Requires the lines to have been sorted before use
+func (bf *Bedfile) DeduplicateLines() {
+	var deduplicatedLines []Line
+	for i, line := range bf.Lines {
+		if i != 0 && strings.Join(line.Full, ",") == strings.Join(bf.Lines[i-1].Full, ",") {
+			continue
+		}
+		deduplicatedLines = append(deduplicatedLines, line)
+	}
+	bf.Lines = deduplicatedLines
+}

--- a/internal/bed/deduplicate_test.go
+++ b/internal/bed/deduplicate_test.go
@@ -1,0 +1,142 @@
+package bed
+
+import (
+	"testing"
+
+	"github.com/go-test/deep"
+)
+
+func TestDeduplicateLines(t *testing.T) {
+	t.Parallel()
+	type testCase struct {
+		testing     string
+		bed         Bedfile
+		expectedBed Bedfile
+		shouldFail  bool
+	}
+	testCases := []testCase{
+		{
+			testing: "simple bed file, with duplicates",
+			bed: Bedfile{
+				Inputs: []string{"test.bed"},
+				Lines: []Line{
+					{
+						Chr: "1", Start: 10, Stop: 100,
+						Full: []string{"1", "10", "100"},
+					},
+					{
+						Chr: "2", Start: 20, Stop: 200,
+						Full: []string{"2", "20", "200"},
+					},
+					{
+						Chr: "1", Start: 10, Stop: 100,
+						Full: []string{"1", "10", "100"},
+					},
+					{
+						Chr: "3", Start: 30, Stop: 300,
+						Full: []string{"3", "30", "300"},
+					},
+					{
+						Chr: "4", Start: 40, Stop: 400,
+						Full: []string{"4", "40", "400"},
+					},
+					{
+						Chr: "3", Start: 30, Stop: 300,
+						Full: []string{"3", "30", "300"},
+					},
+				},
+			},
+			expectedBed: Bedfile{
+				Inputs: []string{"test.bed"},
+				Lines: []Line{
+					{
+						Chr: "1", Start: 10, Stop: 100,
+						Full: []string{"1", "10", "100"},
+					},
+					{
+						Chr: "2", Start: 20, Stop: 200,
+						Full: []string{"2", "20", "200"},
+					},
+					{
+						Chr: "3", Start: 30, Stop: 300,
+						Full: []string{"3", "30", "300"},
+					},
+					{
+						Chr: "4", Start: 40, Stop: 400,
+						Full: []string{"4", "40", "400"},
+					},
+				},
+			},
+		},
+		{
+			testing: "complex bed file with strand and feat",
+			bed: Bedfile{
+				Inputs:    []string{"test.bed"},
+				StrandCol: 4 - 1,
+				FeatCol:   5 - 1,
+				Lines: []Line{
+					{
+						Chr: "1", Start: 10, Stop: 100,
+						Strand: "-1", Feat: "A",
+						Full: []string{"1", "10", "100", "-1", "A"},
+					},
+					{
+						Chr: "2", Start: 20, Stop: 200,
+						Strand: "-1", Feat: "B",
+						Full: []string{"2", "20", "200", "-1", "B"},
+					},
+					{
+						Chr: "3", Start: 30, Stop: 300,
+						Strand: "1", Feat: "C",
+						Full: []string{"3", "30", "300", "1", "C"},
+					},
+					{
+						Chr: "4", Start: 40, Stop: 400,
+						Strand: "1", Feat: "D",
+						Full: []string{"4", "40", "400", "1", "D"},
+					},
+				},
+			},
+			expectedBed: Bedfile{
+				Inputs:    []string{"test.bed"},
+				StrandCol: 4 - 1,
+				FeatCol:   5 - 1,
+				Lines: []Line{
+					{
+						Chr: "1", Start: 10, Stop: 100,
+						Strand: "-1", Feat: "A",
+						Full: []string{"1", "10", "100", "-1", "A"},
+					},
+					{
+						Chr: "2", Start: 20, Stop: 200,
+						Strand: "-1", Feat: "B",
+						Full: []string{"2", "20", "200", "-1", "B"},
+					},
+					{
+						Chr: "3", Start: 30, Stop: 300,
+						Strand: "1", Feat: "C",
+						Full: []string{"3", "30", "300", "1", "C"},
+					},
+					{
+						Chr: "4", Start: 40, Stop: 400,
+						Strand: "1", Feat: "D",
+						Full: []string{"4", "40", "400", "1", "D"},
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.testing, func(t *testing.T) {
+			t.Parallel()
+			tc.bed.Lines = naturalSort(tc.bed.Lines)
+			tc.bed.DeduplicateLines()
+			if !tc.shouldFail {
+				if diff := deep.Equal(tc.expectedBed, tc.bed); diff != nil {
+					t.Error("expected VS received bed", diff)
+				}
+			}
+		})
+	}
+}

--- a/internal/bed/read.go
+++ b/internal/bed/read.go
@@ -10,14 +10,19 @@ import (
 	"strings"
 )
 
-// Opening and reading the bed file
+// Opening and reading the bed files
 func (bf *Bedfile) Read() error {
-	file, err := os.Open(bf.Input)
-	if err != nil {
-		return err
+	for _, input := range bf.Inputs {
+		file, err := os.Open(input)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+		if err := bf.read(file); err != nil {
+			return fmt.Errorf("can't read file %s: %q", input, err)
+		}
 	}
-	defer file.Close()
-	return bf.read(file)
+	return nil
 }
 
 // Reading the bed file
@@ -29,6 +34,11 @@ func (bf *Bedfile) read(file io.Reader) error {
 	headerPattern := regexp.MustCompile(`^(browser|track|#)`)
 	strandPattern := regexp.MustCompile(`^(\.|\+|-|\+1|-1|1)$`)
 
+	// If there is already content in bf save the expectedNrOfCols
+	if len(bf.Lines) != 0 {
+		expectedNrOfCols = len(bf.Lines[0].Full)
+	}
+
 	lineNr := 0
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
@@ -37,7 +47,7 @@ func (bf *Bedfile) read(file io.Reader) error {
 
 		lineText := scanner.Text()
 
-		// Handle headers
+		// Handle header
 		if headerPattern.MatchString(lineText) && len(bf.Lines) == 0 {
 			bf.Header = append(bf.Header, lineText)
 			continue
@@ -46,8 +56,8 @@ func (bf *Bedfile) read(file io.Reader) error {
 		// Split line
 		l.Full = strings.Split(lineText, "\t")
 
-		// For the first content line save the number of columns
-		if lineNr == len(bf.Header)+1 {
+		// For the first content line set the number of columns if it is empty
+		if lineNr == len(bf.Header)+1 && expectedNrOfCols == 0 {
 			expectedNrOfCols = len(l.Full)
 			if expectedNrOfCols < minNrCols {
 				return fmt.Errorf("less than 3 columns on line %d: %s", lineNr, lineText)

--- a/internal/bed/read.go
+++ b/internal/bed/read.go
@@ -47,7 +47,7 @@ func (bf *Bedfile) read(file io.Reader) error {
 
 		lineText := scanner.Text()
 
-		// Handle header
+		// Handle headers
 		if headerPattern.MatchString(lineText) && len(bf.Lines) == 0 {
 			bf.Header = append(bf.Header, lineText)
 			continue

--- a/internal/bed/read_test.go
+++ b/internal/bed/read_test.go
@@ -505,6 +505,41 @@ func TestRead(t *testing.T) {
 			shouldFail: true,
 		},
 		{
+			testing: "bed file already contains lines, second file contains different number of columns",
+			bed: Bedfile{
+				Inputs:    []string{"test.bed"},
+				StrandCol: 4 - 1,
+				FeatCol:   5 - 1,
+				Lines: []Line{
+					{
+						Chr: "1", Start: 10, Stop: 100,
+						Strand: "-1", Feat: "A",
+						Full: []string{"1", "10", "100", "-1", "A"},
+					},
+					{
+						Chr: "2", Start: 20, Stop: 200,
+						Strand: "-1", Feat: "B",
+						Full: []string{"2", "20", "200", "-1", "B"},
+					},
+					{
+						Chr: "3", Start: 30, Stop: 300,
+						Strand: "1", Feat: "C",
+						Full: []string{"3", "30", "300", "1", "C"},
+					},
+					{
+						Chr: "4", Start: 40, Stop: 400,
+						Strand: "1", Feat: "D",
+						Full: []string{"4", "40", "400", "1", "D"},
+					},
+				},
+			},
+			bedFileContent: "5\t50\t500\n" +
+				"6\t60\t600\n" +
+				"7\t70\t700\n" +
+				"8\t80\t800\n",
+			shouldFail: true,
+		},
+		{
 			testing: "bed file already contains lines and header, second file also contains header",
 			bed: Bedfile{
 				Inputs:    []string{"test.bed"},

--- a/internal/bed/read_test.go
+++ b/internal/bed/read_test.go
@@ -20,14 +20,14 @@ func TestRead(t *testing.T) {
 		{
 			testing: "simple bed file",
 			bed: Bedfile{
-				Input: "test.bed",
+				Inputs: []string{"test.bed"},
 			},
 			bedFileContent: "1\t10\t100\n" +
 				"2\t20\t200\n" +
 				"3\t30\t300\n" +
 				"4\t40\t400\n",
 			expectedBed: Bedfile{
-				Input: "test.bed",
+				Inputs: []string{"test.bed"},
 				Lines: []Line{
 					{
 						Chr: "1", Start: 10, Stop: 100,
@@ -51,14 +51,14 @@ func TestRead(t *testing.T) {
 		{
 			testing: "simple bed file, equal start and stop",
 			bed: Bedfile{
-				Input: "test.bed",
+				Inputs: []string{"test.bed"},
 			},
 			bedFileContent: "1\t10\t100\n" +
 				"2\t200\t200\n" +
 				"3\t30\t300\n" +
 				"4\t40\t400\n",
 			expectedBed: Bedfile{
-				Input: "test.bed",
+				Inputs: []string{"test.bed"},
 				Lines: []Line{
 					{
 						Chr: "1", Start: 10, Stop: 100,
@@ -82,7 +82,7 @@ func TestRead(t *testing.T) {
 		{
 			testing: "simple bed file with header",
 			bed: Bedfile{
-				Input: "test.bed",
+				Inputs: []string{"test.bed"},
 			},
 			bedFileContent: "browser something\n" +
 				"track something\n" +
@@ -92,7 +92,7 @@ func TestRead(t *testing.T) {
 				"3\t30\t300\n" +
 				"4\t40\t400\n",
 			expectedBed: Bedfile{
-				Input: "test.bed",
+				Inputs: []string{"test.bed"},
 				Header: []string{
 					"browser something",
 					"track something",
@@ -121,7 +121,7 @@ func TestRead(t *testing.T) {
 		{
 			testing: "complex bed file with strand and feat",
 			bed: Bedfile{
-				Input:     "test.bed",
+				Inputs:    []string{"test.bed"},
 				StrandCol: 4 - 1,
 				FeatCol:   5 - 1,
 			},
@@ -130,7 +130,7 @@ func TestRead(t *testing.T) {
 				"3\t30\t300\t1\tC\n" +
 				"4\t40\t400\t1\tD\n",
 			expectedBed: Bedfile{
-				Input:     "test.bed",
+				Inputs:    []string{"test.bed"},
 				StrandCol: 4 - 1,
 				FeatCol:   5 - 1,
 				Lines: []Line{
@@ -158,9 +158,181 @@ func TestRead(t *testing.T) {
 			},
 		},
 		{
+			testing: "bed file already contains lines",
+			bed: Bedfile{
+				Inputs:    []string{"test.bed"},
+				StrandCol: 4 - 1,
+				FeatCol:   5 - 1,
+				Lines: []Line{
+					{
+						Chr: "1", Start: 10, Stop: 100,
+						Strand: "-1", Feat: "A",
+						Full: []string{"1", "10", "100", "-1", "A"},
+					},
+					{
+						Chr: "2", Start: 20, Stop: 200,
+						Strand: "-1", Feat: "B",
+						Full: []string{"2", "20", "200", "-1", "B"},
+					},
+					{
+						Chr: "3", Start: 30, Stop: 300,
+						Strand: "1", Feat: "C",
+						Full: []string{"3", "30", "300", "1", "C"},
+					},
+					{
+						Chr: "4", Start: 40, Stop: 400,
+						Strand: "1", Feat: "D",
+						Full: []string{"4", "40", "400", "1", "D"},
+					},
+				},
+			},
+			bedFileContent: "5\t50\t500\t-1\tE\n" +
+				"6\t60\t600\t-1\tF\n" +
+				"7\t70\t700\t1\tG\n" +
+				"8\t80\t800\t1\tH\n",
+			expectedBed: Bedfile{
+				Inputs:    []string{"test.bed"},
+				StrandCol: 4 - 1,
+				FeatCol:   5 - 1,
+				Lines: []Line{
+					{
+						Chr: "1", Start: 10, Stop: 100,
+						Strand: "-1", Feat: "A",
+						Full: []string{"1", "10", "100", "-1", "A"},
+					},
+					{
+						Chr: "2", Start: 20, Stop: 200,
+						Strand: "-1", Feat: "B",
+						Full: []string{"2", "20", "200", "-1", "B"},
+					},
+					{
+						Chr: "3", Start: 30, Stop: 300,
+						Strand: "1", Feat: "C",
+						Full: []string{"3", "30", "300", "1", "C"},
+					},
+					{
+						Chr: "4", Start: 40, Stop: 400,
+						Strand: "1", Feat: "D",
+						Full: []string{"4", "40", "400", "1", "D"},
+					},
+					{
+						Chr: "5", Start: 50, Stop: 500,
+						Strand: "-1", Feat: "E",
+						Full: []string{"5", "50", "500", "-1", "E"},
+					},
+					{
+						Chr: "6", Start: 60, Stop: 600,
+						Strand: "-1", Feat: "F",
+						Full: []string{"6", "60", "600", "-1", "F"},
+					},
+					{
+						Chr: "7", Start: 70, Stop: 700,
+						Strand: "1", Feat: "G",
+						Full: []string{"7", "70", "700", "1", "G"},
+					},
+					{
+						Chr: "8", Start: 80, Stop: 800,
+						Strand: "1", Feat: "H",
+						Full: []string{"8", "80", "800", "1", "H"},
+					},
+				},
+			},
+		},
+		{
+			testing: "bed file already contains lines and header, second file does NOT contain header",
+			bed: Bedfile{
+				Inputs:    []string{"test.bed"},
+				StrandCol: 4 - 1,
+				FeatCol:   5 - 1,
+				Header: []string{
+					"browser something",
+					"track something",
+					"#something",
+				},
+				Lines: []Line{
+					{
+						Chr: "1", Start: 10, Stop: 100,
+						Strand: "-1", Feat: "A",
+						Full: []string{"1", "10", "100", "-1", "A"},
+					},
+					{
+						Chr: "2", Start: 20, Stop: 200,
+						Strand: "-1", Feat: "B",
+						Full: []string{"2", "20", "200", "-1", "B"},
+					},
+					{
+						Chr: "3", Start: 30, Stop: 300,
+						Strand: "1", Feat: "C",
+						Full: []string{"3", "30", "300", "1", "C"},
+					},
+					{
+						Chr: "4", Start: 40, Stop: 400,
+						Strand: "1", Feat: "D",
+						Full: []string{"4", "40", "400", "1", "D"},
+					},
+				},
+			},
+			bedFileContent: "5\t50\t500\t-1\tE\n" +
+				"6\t60\t600\t-1\tF\n" +
+				"7\t70\t700\t1\tG\n" +
+				"8\t80\t800\t1\tH\n",
+			expectedBed: Bedfile{
+				Inputs:    []string{"test.bed"},
+				StrandCol: 4 - 1,
+				FeatCol:   5 - 1,
+				Header: []string{
+					"browser something",
+					"track something",
+					"#something",
+				},
+				Lines: []Line{
+					{
+						Chr: "1", Start: 10, Stop: 100,
+						Strand: "-1", Feat: "A",
+						Full: []string{"1", "10", "100", "-1", "A"},
+					},
+					{
+						Chr: "2", Start: 20, Stop: 200,
+						Strand: "-1", Feat: "B",
+						Full: []string{"2", "20", "200", "-1", "B"},
+					},
+					{
+						Chr: "3", Start: 30, Stop: 300,
+						Strand: "1", Feat: "C",
+						Full: []string{"3", "30", "300", "1", "C"},
+					},
+					{
+						Chr: "4", Start: 40, Stop: 400,
+						Strand: "1", Feat: "D",
+						Full: []string{"4", "40", "400", "1", "D"},
+					},
+					{
+						Chr: "5", Start: 50, Stop: 500,
+						Strand: "-1", Feat: "E",
+						Full: []string{"5", "50", "500", "-1", "E"},
+					},
+					{
+						Chr: "6", Start: 60, Stop: 600,
+						Strand: "-1", Feat: "F",
+						Full: []string{"6", "60", "600", "-1", "F"},
+					},
+					{
+						Chr: "7", Start: 70, Stop: 700,
+						Strand: "1", Feat: "G",
+						Full: []string{"7", "70", "700", "1", "G"},
+					},
+					{
+						Chr: "8", Start: 80, Stop: 800,
+						Strand: "1", Feat: "H",
+						Full: []string{"8", "80", "800", "1", "H"},
+					},
+				},
+			},
+		},
+		{
 			testing: "complex bed file with strand and feat and header",
 			bed: Bedfile{
-				Input:     "test.bed",
+				Inputs:    []string{"test.bed"},
 				StrandCol: 4 - 1,
 				FeatCol:   6 - 1,
 			},
@@ -172,7 +344,7 @@ func TestRead(t *testing.T) {
 				"10\t126085871\t126107545\t-1\tOAT\tENSG00000065154\n" +
 				"X\t135067597\t135129423\t1\tSLC9A6\tENSG00000198689",
 			expectedBed: Bedfile{
-				Input:     "test.bed",
+				Inputs:    []string{"test.bed"},
 				StrandCol: 4 - 1,
 				FeatCol:   6 - 1,
 				Header:    []string{"#a test header"},
@@ -213,7 +385,7 @@ func TestRead(t *testing.T) {
 		{
 			testing: "stop less than start",
 			bed: Bedfile{
-				Input: "test.bed",
+				Inputs: []string{"test.bed"},
 			},
 			bedFileContent: "1\t10\t100\n" +
 				"2\t20\t200\n" +
@@ -224,7 +396,7 @@ func TestRead(t *testing.T) {
 		{
 			testing: "missing column",
 			bed: Bedfile{
-				Input: "test.bed",
+				Inputs: []string{"test.bed"},
 			},
 			bedFileContent: "10\t100\n" +
 				"20\t200\n" +
@@ -235,7 +407,7 @@ func TestRead(t *testing.T) {
 		{
 			testing: "changing column numbers",
 			bed: Bedfile{
-				Input: "test.bed",
+				Inputs: []string{"test.bed"},
 			},
 			bedFileContent: "1\t10\t100\n" +
 				"2\t20\t200\n" +
@@ -246,7 +418,7 @@ func TestRead(t *testing.T) {
 		{
 			testing: "start not a number",
 			bed: Bedfile{
-				Input: "test.bed",
+				Inputs: []string{"test.bed"},
 			},
 			bedFileContent: "1\tX\t100\n" +
 				"2\t20\t200\n" +
@@ -257,7 +429,7 @@ func TestRead(t *testing.T) {
 		{
 			testing: "stop not a number",
 			bed: Bedfile{
-				Input: "test.bed",
+				Inputs: []string{"test.bed"},
 			},
 			bedFileContent: "1\t10\t100\n" +
 				"2\t20\t200\n" +
@@ -268,7 +440,7 @@ func TestRead(t *testing.T) {
 		{
 			testing: "unknown header",
 			bed: Bedfile{
-				Input: "test.bed",
+				Inputs: []string{"test.bed"},
 			},
 			bedFileContent: "something\n" +
 				"1\t10\t100\n" +
@@ -280,7 +452,7 @@ func TestRead(t *testing.T) {
 		{
 			testing: "multi track file",
 			bed: Bedfile{
-				Input: "test.bed",
+				Inputs: []string{"test.bed"},
 			},
 			bedFileContent: "browser something\n" +
 				"track something\n" +
@@ -296,7 +468,7 @@ func TestRead(t *testing.T) {
 		{
 			testing: "strand in incorrect format",
 			bed: Bedfile{
-				Input:     "test.bed",
+				Inputs:    []string{"test.bed"},
 				StrandCol: 4 - 1,
 				FeatCol:   5 - 1,
 			},
@@ -309,7 +481,7 @@ func TestRead(t *testing.T) {
 		{
 			testing: "strand col outside bed",
 			bed: Bedfile{
-				Input:     "test.bed",
+				Inputs:    []string{"test.bed"},
 				StrandCol: 6 - 1,
 				FeatCol:   5 - 1,
 			},
@@ -322,7 +494,7 @@ func TestRead(t *testing.T) {
 		{
 			testing: "feat col outside bed",
 			bed: Bedfile{
-				Input:     "test.bed",
+				Inputs:    []string{"test.bed"},
 				StrandCol: 4 - 1,
 				FeatCol:   6 - 1,
 			},
@@ -330,6 +502,49 @@ func TestRead(t *testing.T) {
 				"2\t20\t200\t-1\tB\n" +
 				"3\t30\t300\t1\tC\n" +
 				"4\t40\t400\t1\tD\n",
+			shouldFail: true,
+		},
+		{
+			testing: "bed file already contains lines and header, second file also contains header",
+			bed: Bedfile{
+				Inputs:    []string{"test.bed"},
+				StrandCol: 4 - 1,
+				FeatCol:   5 - 1,
+				Header: []string{
+					"browser something",
+					"track something",
+					"#something",
+				},
+				Lines: []Line{
+					{
+						Chr: "1", Start: 10, Stop: 100,
+						Strand: "-1", Feat: "A",
+						Full: []string{"1", "10", "100", "-1", "A"},
+					},
+					{
+						Chr: "2", Start: 20, Stop: 200,
+						Strand: "-1", Feat: "B",
+						Full: []string{"2", "20", "200", "-1", "B"},
+					},
+					{
+						Chr: "3", Start: 30, Stop: 300,
+						Strand: "1", Feat: "C",
+						Full: []string{"3", "30", "300", "1", "C"},
+					},
+					{
+						Chr: "4", Start: 40, Stop: 400,
+						Strand: "1", Feat: "D",
+						Full: []string{"4", "40", "400", "1", "D"},
+					},
+				},
+			},
+			bedFileContent: "browser something\n" +
+				"track something\n" +
+				"#something\n" +
+				"5\t50\t500\t-1\tE\n" +
+				"6\t60\t600\t-1\tF\n" +
+				"7\t70\t700\t1\tG\n" +
+				"8\t80\t800\t1\tH\n",
 			shouldFail: true,
 		},
 	}

--- a/internal/bed/writer_test.go
+++ b/internal/bed/writer_test.go
@@ -122,7 +122,7 @@ func TestToString(t *testing.T) {
 		{
 			testing: "bed file with headers",
 			bed: Bedfile{
-				Input: "test.bed",
+				Inputs: []string{"test.bed"},
 				Header: []string{
 					"browser something",
 					"track something",


### PR DESCRIPTION
This PR adds:
- The ability to provide more than one bed file as input (note that we still only provide limited track file support and only allow headers in the first file that was provided)
- The option to deduplicate the lines. Since merging will get rid off duplicated lines  the `--deduplicate`/`-d` flag does nothing unless `--no-merge` is also chosen.