### PR TITLE
Feat: Use alpine and switch from endpoint to cmd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM debian:bookworm
+FROM alpine:3.21.0
 COPY bedfusion /bedfusion
-ENTRYPOINT ["/bedfusion"]
+CMD ["/bedfusion"]


### PR DESCRIPTION
Switched from debian to alpine to shrink the dockerimage a bit. 